### PR TITLE
Add new permissions and restructure controllers

### DIFF
--- a/TeamA.ToDo.EntityFramework/DataSeeder.cs
+++ b/TeamA.ToDo.EntityFramework/DataSeeder.cs
@@ -168,7 +168,8 @@ public class DataSeeder
             {
                 new Permission { Name = "ViewSystemLogs", Description = "Can view system logs", Category = "SystemManagement" },
                 new Permission { Name = "ManageSettings", Description = "Can manage application settings", Category = "SystemManagement" },
-                new Permission { Name = "ViewStatistics", Description = "Can view system statistics", Category = "SystemManagement" }
+                new Permission { Name = "ViewStatistics", Description = "Can view system statistics", Category = "SystemManagement" },
+                new Permission { Name = "ViewAllExpenses", Description = "Can view all users' expenses", Category = "SystemManagement" }
             }
         };
 

--- a/TeamA.ToDo/Controllers/Auth/AuthenticationController.cs
+++ b/TeamA.ToDo/Controllers/Auth/AuthenticationController.cs
@@ -6,7 +6,7 @@ using TeamA.ToDo.Application.DTOs.General;
 using TeamA.ToDo.Application.Interfaces;
 using TeamA.ToDo.Core.Models;
 
-namespace TeamA.ToDo.Controllers;
+namespace TeamA.ToDo.Host.Controllers.Auth;
 
 // Controllers/AuthController.cs
 [ApiController]

--- a/TeamA.ToDo/Controllers/Auth/RolesController.cs
+++ b/TeamA.ToDo/Controllers/Auth/RolesController.cs
@@ -4,7 +4,7 @@ using TeamA.ToDo.Application.DTOs.General;
 using TeamA.ToDo.Application.DTOs.Roles;
 using TeamA.ToDo.Application.Interfaces;
 
-namespace TeamA.ToDo.Controllers;
+namespace TeamA.ToDo.Host.Controllers.Auth;
 
 [ApiController]
 [Route("api/roles")]

--- a/TeamA.ToDo/Controllers/Auth/UserSettingsController.cs
+++ b/TeamA.ToDo/Controllers/Auth/UserSettingsController.cs
@@ -13,7 +13,7 @@ using TeamA.ToDo.Application.Security;
 using TeamA.ToDo.Core.Models;
 using TeamA.ToDo.Core.Models.General;
 
-namespace TeamA.ToDo.Controllers;
+namespace TeamA.ToDo.Host.Controllers.Auth;
 
 [ApiController]
 [Route("api/user-settings")]

--- a/TeamA.ToDo/Controllers/Auth/UsersController.cs
+++ b/TeamA.ToDo/Controllers/Auth/UsersController.cs
@@ -8,7 +8,7 @@ using TeamA.ToDo.Application.DTOs.Users;
 using TeamA.ToDo.Application.Interfaces;
 using TeamA.ToDo.Core.Models;
 
-namespace TeamA.ToDo.Controllers;
+namespace TeamA.ToDo.Host.Controllers.Auth;
 
 [ApiController]
 [Route("api/users")]

--- a/TeamA.ToDo/Controllers/Expense/BudgetsController.cs
+++ b/TeamA.ToDo/Controllers/Expense/BudgetsController.cs
@@ -1,0 +1,141 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TeamA.ToDo.Application.DTOs.Expenses;
+using TeamA.ToDo.Application.DTOs.General;
+using TeamA.ToDo.Application.Interfaces.Expenses;
+
+namespace TeamA.ToDo.Host.Controllers.Expense;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class BudgetsController : ControllerBase
+{
+    private readonly IBudgetService _budgetService;
+    private readonly ILogger<BudgetsController> _logger;
+
+    public BudgetsController(
+        IBudgetService budgetService,
+        ILogger<BudgetsController> logger)
+    {
+        _budgetService = budgetService;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(ServiceResponse<List<BudgetDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetBudgets()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _budgetService.GetBudgetsAsync(userId);
+        return Ok(response);
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<BudgetDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<BudgetDto>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetBudgetById(Guid id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _budgetService.GetBudgetByIdAsync(id, userId);
+
+        if (!response.Success)
+        {
+            return NotFound(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(ServiceResponse<BudgetDto>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ServiceResponse<BudgetDto>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreateBudget([FromBody] CreateBudgetDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new ServiceResponse<BudgetDto>
+            {
+                Success = false,
+                Message = "Invalid input",
+                Errors = ModelState.Values.SelectMany(v => v.Errors)
+                    .Select(e => e.ErrorMessage)
+                    .ToList()
+            });
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _budgetService.CreateBudgetAsync(userId, dto);
+
+        if (!response.Success)
+        {
+            return BadRequest(response);
+        }
+
+        return CreatedAtAction(nameof(GetBudgetById), new { id = response.Data.Id }, response);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<BudgetDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<BudgetDto>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ServiceResponse<BudgetDto>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateBudget(Guid id, [FromBody] UpdateBudgetDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new ServiceResponse<BudgetDto>
+            {
+                Success = false,
+                Message = "Invalid input",
+                Errors = ModelState.Values.SelectMany(v => v.Errors)
+                    .Select(e => e.ErrorMessage)
+                    .ToList()
+            });
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _budgetService.UpdateBudgetAsync(id, userId, dto);
+
+        if (!response.Success)
+        {
+            if (response.Message.Contains("not found"))
+            {
+                return NotFound(response);
+            }
+            return BadRequest(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteBudget(Guid id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _budgetService.DeleteBudgetAsync(id, userId);
+
+        if (!response.Success)
+        {
+            if (response.Message.Contains("not found"))
+            {
+                return NotFound(response);
+            }
+            return BadRequest(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpGet("summary")]
+    [ProducesResponseType(typeof(ServiceResponse<BudgetSummaryDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetBudgetSummary([FromQuery] DateTime? month)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _budgetService.GetBudgetSummaryAsync(userId, month);
+        return Ok(response);
+    }
+}

--- a/TeamA.ToDo/Controllers/Expense/ExpenseCategoriesController.cs
+++ b/TeamA.ToDo/Controllers/Expense/ExpenseCategoriesController.cs
@@ -1,0 +1,132 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TeamA.ToDo.Application.DTOs.Expenses;
+using TeamA.ToDo.Application.DTOs.General;
+using TeamA.ToDo.Application.Interfaces.Expenses;
+
+namespace TeamA.ToDo.Host.Controllers.Expense;
+
+[ApiController]
+[Route("api/expense-categories")]
+[Authorize]
+public class ExpenseCategoriesController : ControllerBase
+{
+    private readonly IExpenseCategoryService _categoryService;
+    private readonly ILogger<ExpenseCategoriesController> _logger;
+
+    public ExpenseCategoriesController(
+        IExpenseCategoryService categoryService,
+        ILogger<ExpenseCategoriesController> logger)
+    {
+        _categoryService = categoryService;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(ServiceResponse<List<ExpenseCategoryDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetCategories()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _categoryService.GetCategoriesAsync(userId);
+        return Ok(response);
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseCategoryDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseCategoryDto>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetCategoryById(Guid id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _categoryService.GetCategoryByIdAsync(id, userId);
+
+        if (!response.Success)
+        {
+            return NotFound(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseCategoryDto>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseCategoryDto>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreateCategory([FromBody] CreateExpenseCategoryDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new ServiceResponse<ExpenseCategoryDto>
+            {
+                Success = false,
+                Message = "Invalid input",
+                Errors = ModelState.Values.SelectMany(v => v.Errors)
+                    .Select(e => e.ErrorMessage)
+                    .ToList()
+            });
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _categoryService.CreateCategoryAsync(userId, dto);
+
+        if (!response.Success)
+        {
+            return BadRequest(response);
+        }
+
+        return CreatedAtAction(nameof(GetCategoryById), new { id = response.Data.Id }, response);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseCategoryDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseCategoryDto>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseCategoryDto>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateCategory(Guid id, [FromBody] UpdateExpenseCategoryDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new ServiceResponse<ExpenseCategoryDto>
+            {
+                Success = false,
+                Message = "Invalid input",
+                Errors = ModelState.Values.SelectMany(v => v.Errors)
+                    .Select(e => e.ErrorMessage)
+                    .ToList()
+            });
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _categoryService.UpdateCategoryAsync(id, userId, dto);
+
+        if (!response.Success)
+        {
+            if (response.Message.Contains("not found"))
+            {
+                return NotFound(response);
+            }
+            return BadRequest(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> DeleteCategory(Guid id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _categoryService.DeleteCategoryAsync(id, userId);
+
+        if (!response.Success)
+        {
+            if (response.Message.Contains("not found"))
+            {
+                return NotFound(response);
+            }
+            return BadRequest(response);
+        }
+
+        return Ok(response);
+    }
+}

--- a/TeamA.ToDo/Controllers/Expense/ExpensesController.cs
+++ b/TeamA.ToDo/Controllers/Expense/ExpensesController.cs
@@ -1,0 +1,146 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TeamA.ToDo.Application.DTOs.Expenses;
+using TeamA.ToDo.Application.DTOs.General;
+using TeamA.ToDo.Application.Interfaces.Expenses;
+
+namespace TeamA.ToDo.Host.Controllers.Expense;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class ExpensesController : ControllerBase
+{
+    private readonly IExpenseService _expenseService;
+    private readonly ILogger<ExpensesController> _logger;
+
+    public ExpensesController(
+        IExpenseService expenseService,
+        ILogger<ExpensesController> logger)
+    {
+        _expenseService = expenseService;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(PagedResponse<ExpenseDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetExpenses([FromQuery] ExpenseFilterDto filter)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var result = await _expenseService.GetExpensesAsync(userId, filter);
+        return Ok(result);
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseDto>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetExpenseById(Guid id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _expenseService.GetExpenseByIdAsync(id, userId);
+
+        if (!response.Success)
+        {
+            return NotFound(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseDto>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseDto>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreateExpense([FromBody] CreateExpenseDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new ServiceResponse<ExpenseDto>
+            {
+                Success = false,
+                Message = "Invalid input",
+                Errors = ModelState.Values.SelectMany(v => v.Errors)
+                                        .Select(e => e.ErrorMessage)
+                                        .ToList()
+            });
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _expenseService.CreateExpenseAsync(userId, dto);
+
+        if (!response.Success)
+        {
+            return BadRequest(response);
+        }
+
+        return CreatedAtAction(nameof(GetExpenseById), new { id = response.Data.Id }, response);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseDto>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseDto>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateExpense(Guid id, [FromBody] UpdateExpenseDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new ServiceResponse<ExpenseDto>
+            {
+                Success = false,
+                Message = "Invalid input",
+                Errors = ModelState.Values.SelectMany(v => v.Errors)
+                                        .Select(e => e.ErrorMessage)
+                                        .ToList()
+            });
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _expenseService.UpdateExpenseAsync(id, userId, dto);
+
+        if (!response.Success)
+        {
+            if (response.Message.Contains("not found"))
+            {
+                return NotFound(response);
+            }
+            return BadRequest(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteExpense(Guid id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _expenseService.DeleteExpenseAsync(id, userId);
+
+        if (!response.Success)
+        {
+            return NotFound(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpGet("statistics")]
+    [ProducesResponseType(typeof(ServiceResponse<ExpenseStatisticsDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetStatistics([FromQuery] DateTime? startDate, [FromQuery] DateTime? endDate)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _expenseService.GetExpenseStatisticsAsync(userId, startDate, endDate);
+        return Ok(response);
+    }
+
+    // Admin-only endpoint similar to TodoTask's "all" endpoint
+    [HttpGet("all")]
+    [Authorize(Policy = "CanViewAllExpenses")]
+    [ProducesResponseType(typeof(ServiceResponse<PagedResponse<ExpenseDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAllExpenses([FromQuery] ExpenseFilterDto filter)
+    {
+        var response = await _expenseService.GetAllExpensesAsync(filter);
+        return Ok(response);
+    }
+}

--- a/TeamA.ToDo/Controllers/Expense/PaymentMethodsController.cs
+++ b/TeamA.ToDo/Controllers/Expense/PaymentMethodsController.cs
@@ -1,0 +1,153 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TeamA.ToDo.Application.DTOs.Expenses;
+using TeamA.ToDo.Application.DTOs.General;
+using TeamA.ToDo.Application.Interfaces.Expenses;
+
+namespace TeamA.ToDo.Host.Controllers.Expense;
+
+[ApiController]
+[Route("api/payment-methods")]
+[Authorize]
+public class PaymentMethodsController : ControllerBase
+{
+    private readonly IPaymentMethodService _paymentMethodService;
+    private readonly ILogger<PaymentMethodsController> _logger;
+
+    public PaymentMethodsController(
+        IPaymentMethodService paymentMethodService,
+        ILogger<PaymentMethodsController> logger)
+    {
+        _paymentMethodService = paymentMethodService;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(ServiceResponse<List<PaymentMethodDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPaymentMethods()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _paymentMethodService.GetPaymentMethodsAsync(userId);
+        return Ok(response);
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<PaymentMethodDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<PaymentMethodDto>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPaymentMethodById(Guid id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _paymentMethodService.GetPaymentMethodByIdAsync(id, userId);
+
+        if (!response.Success)
+        {
+            return NotFound(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(ServiceResponse<PaymentMethodDto>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ServiceResponse<PaymentMethodDto>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreatePaymentMethod([FromBody] CreatePaymentMethodDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new ServiceResponse<PaymentMethodDto>
+            {
+                Success = false,
+                Message = "Invalid input",
+                Errors = ModelState.Values.SelectMany(v => v.Errors)
+                    .Select(e => e.ErrorMessage)
+                    .ToList()
+            });
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _paymentMethodService.CreatePaymentMethodAsync(userId, dto);
+
+        if (!response.Success)
+        {
+            return BadRequest(response);
+        }
+
+        return CreatedAtAction(nameof(GetPaymentMethodById), new { id = response.Data.Id }, response);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<PaymentMethodDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<PaymentMethodDto>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ServiceResponse<PaymentMethodDto>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdatePaymentMethod(Guid id, [FromBody] UpdatePaymentMethodDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new ServiceResponse<PaymentMethodDto>
+            {
+                Success = false,
+                Message = "Invalid input",
+                Errors = ModelState.Values.SelectMany(v => v.Errors)
+                    .Select(e => e.ErrorMessage)
+                    .ToList()
+            });
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _paymentMethodService.UpdatePaymentMethodAsync(id, userId, dto);
+
+        if (!response.Success)
+        {
+            if (response.Message.Contains("not found"))
+            {
+                return NotFound(response);
+            }
+            return BadRequest(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeletePaymentMethod(Guid id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _paymentMethodService.DeletePaymentMethodAsync(id, userId);
+
+        if (!response.Success)
+        {
+            if (response.Message.Contains("not found"))
+            {
+                return NotFound(response);
+            }
+            return BadRequest(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpPost("{id}/set-default")]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ServiceResponse<bool>), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> SetDefaultPaymentMethod(Guid id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var response = await _paymentMethodService.SetDefaultPaymentMethodAsync(id, userId);
+
+        if (!response.Success)
+        {
+            if (response.Message.Contains("not found"))
+            {
+                return NotFound(response);
+            }
+            return BadRequest(response);
+        }
+
+        return Ok(response);
+    }
+}

--- a/TeamA.ToDo/Controllers/Todo/CategoriesController.cs
+++ b/TeamA.ToDo/Controllers/Todo/CategoriesController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using TeamA.ToDo.Application.Interfaces;
 using TodoApp.API.DTOs;
 
-namespace TeamA.ToDo.Host.Controllers;
+namespace TeamA.ToDo.Host.Controllers.Todo;
 
 [ApiController]
 [Route("api/[controller]")]

--- a/TeamA.ToDo/Controllers/Todo/NotesController.cs
+++ b/TeamA.ToDo/Controllers/Todo/NotesController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using TeamA.ToDo.Application.Interfaces;
 using TodoApp.API.DTOs;
 
-namespace TeamA.ToDo.Host.Controllers;
+namespace TeamA.ToDo.Host.Controllers.Todo;
 
 [ApiController]
 [Route("api/tasks/{taskId}/notes")]

--- a/TeamA.ToDo/Controllers/Todo/RemindersController.cs
+++ b/TeamA.ToDo/Controllers/Todo/RemindersController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using TeamA.ToDo.Application.Interfaces;
 using TodoApp.API.DTOs;
 
-namespace TeamA.ToDo.Host.Controllers;
+namespace TeamA.ToDo.Host.Controllers.Todo;
 
 [ApiController]
 [Route("api/tasks/{taskId}/reminders")]

--- a/TeamA.ToDo/Controllers/Todo/TagsController.cs
+++ b/TeamA.ToDo/Controllers/Todo/TagsController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using TeamA.ToDo.Application.Interfaces;
 using TodoApp.API.DTOs;
 
-namespace TeamA.ToDo.Host.Controllers;
+namespace TeamA.ToDo.Host.Controllers.Todo;
 
 [ApiController]
 [Route("api/[controller]")]

--- a/TeamA.ToDo/Controllers/Todo/TasksController.cs
+++ b/TeamA.ToDo/Controllers/Todo/TasksController.cs
@@ -6,7 +6,7 @@ using TeamA.ToDo.Application.Interfaces;
 using TeamA.ToDo.Core.Shared.Enums.Todo;
 using TodoApp.API.DTOs;
 
-namespace TeamA.ToDo.Host.Controllers
+namespace TeamA.ToDo.Host.Controllers.Todo
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/TeamA.ToDo/Extensions/AuthExtensions.cs
+++ b/TeamA.ToDo/Extensions/AuthExtensions.cs
@@ -106,6 +106,9 @@ public static class AuthExtensions
 
             options.AddPolicy("TodoOwnerPolicy", policy =>
                 policy.Requirements.Add(new ToDoOwnerRequirement()));
+
+            options.AddPolicy("CanViewAllExpenses", policy =>
+                policy.RequireRole("Admin").RequireClaim("Permission", "ViewAllExpenses"));
         });
 
         // Register authorization handler


### PR DESCRIPTION
Add new permissions and restructure controllers

- Updated `DataSeeder.cs` to include "ViewAllExpenses" permission.
- Changed namespaces for several controllers to `TeamA.ToDo.Host.Controllers.Auth` and `TeamA.ToDo.Host.Controllers.Todo`.
- Introduced new controllers for budgets, expense categories, expenses, and payment methods with full CRUD operations.
- Added a new authorization policy "CanViewAllExpenses" in `AuthExtensions.cs`.

#### PR Classification
New feature implementation and project restructuring.

#### PR Summary
This pull request introduces new controllers for managing budgets and expenses, updates existing controller namespaces for better organization, and adds a new permission for viewing all expenses. 
- `DataSeeder.cs`: Added "ViewAllExpenses" permission in the "SystemManagement" category.
- `BudgetsController.cs`, `ExpenseCategoriesController.cs`, `ExpensesController.cs`, `PaymentMethodsController.cs`: New controllers added for handling budgets and expenses with CRUD operations.
- `AuthenticationController.cs`, `RolesController.cs`, `UserSettingsController.cs`, `UsersController.cs`: Namespace changed to `TeamA.ToDo.Host.Controllers.Auth`.
- `CategoriesController.cs`, `NotesController.cs`, `RemindersController.cs`, `TagsController.cs`, `TasksController.cs`: Namespace changed to `TeamA.ToDo.Host.Controllers.Todo`.
- `AuthExtensions.cs`: Added "CanViewAllExpenses" authorization policy requiring "Admin" role and "ViewAllExpenses" permission.
